### PR TITLE
Find multiple orders

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,38 +1,48 @@
 PATH
   remote: .
   specs:
-    flybuy (0.1.0)
+    flybuy (0.1.4)
       activemodel
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.6)
-      activesupport (= 7.0.6)
-    activesupport (7.0.6)
+    activemodel (7.1.3.2)
+      activesupport (= 7.1.3.2)
+    activesupport (7.1.3.2)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-    concurrent-ruby (1.2.2)
-    diff-lcs (1.5.0)
-    i18n (1.14.1)
+    base64 (0.2.0)
+    bigdecimal (3.1.7)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
+    diff-lcs (1.5.1)
+    drb (2.2.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
-    minitest (5.19.0)
-    rake (13.0.6)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    minitest (5.22.3)
+    mutex_m (0.2.0)
+    rake (13.1.0)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.6)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.1)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 

--- a/lib/flybuy/order.rb
+++ b/lib/flybuy/order.rb
@@ -14,7 +14,7 @@ module Flybuy
                     area_name possible_areas customer_id site_id site_partner_identifier spot_identifier
                     customer_name customer_car_type customer_car_color customer_license_plate customer_rating_value
                     customer_rating_comments pickup_window pickup_type push_token tag_ids delivery_error_reviewed_at
-                    delivery_errored_at delivery_identifier delivery_source pos_identifier].freeze
+                    delivery_errored_at delivery_identifier delivery_source pos_identifier pay_state].freeze
     attr_accessor(*ATTRIBUTES)
 
     def initialize(client: nil, data: nil)
@@ -56,7 +56,7 @@ module Flybuy
       return if order_id.nil?
 
       client = Flybuy.client
-      response = client.put("orders/#{order_id}", create_or_update_payload(params))
+      response = client.put("orders/#{order_id}", Flybuy::Order.create_or_update_payload(params))
       return nil if response[:data].empty?
 
       Flybuy::Order.new(client: client, data: response[:data])

--- a/lib/flybuy/order.rb
+++ b/lib/flybuy/order.rb
@@ -36,12 +36,16 @@ module Flybuy
       Flybuy::Order.new(client: client, data: response[:data])
     end
 
-    def self.find_by_partner_identifier(partner_identifier)
+    def self.find_by_partner_identifier(partner_identifier, all: false)
       client = Flybuy.client
       response = client.get('orders', { partner_identifier: partner_identifier })
       return nil if response[:data].empty?
 
-      Flybuy::Order.new(client: client, data: response[:data].first)
+      orders = response[:data].map { |order| Flybuy::Order.new(client: client, data: order) }
+      return orders if all
+
+      # initial versions of the gem only returned one order.  Defaulting to all: false maintains compatibility.
+      orders.first
     end
 
     def self.find(id)

--- a/lib/flybuy/version.rb
+++ b/lib/flybuy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Flybuy
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/lib/flybuy/version.rb
+++ b/lib/flybuy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Flybuy
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
Previously `find_by_partner_identifier` for orders would only return the first order.  This changes adds an optional parameter `all` (defaulted to false).  If set to `true`, `find_by_partner_identifier` will return an array of orders instead of the first order.