### PR TITLE
add delivery_source and option to return hash

### DIFF
--- a/lib/flybuy/version.rb
+++ b/lib/flybuy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Flybuy
-  VERSION = '0.1.6'
+  VERSION = '0.1.7'
 end


### PR DESCRIPTION
Adds the newish attribute `delivery_source` to the ArchivedOrder model.

Adds the option to return archived orders as a hash instead of instaciating ArchivedOrder objects for each one.